### PR TITLE
Add dependency on azurerm_container_registry.main

### DIFF
--- a/modules/container-app/host/container-image.tf
+++ b/modules/container-app/host/container-image.tf
@@ -12,4 +12,5 @@ az acr build \
     "https://github.com/Azure-Samples/container-apps-ci-cd-runner-tutorial.git"
 EOF
   }
+  depends_on = [azurerm_container_registry.main]
 }


### PR DESCRIPTION
Added dependency on the Azure Container Registry to prevent the null resource executing the local-exec from firing off too soon and erroring out.